### PR TITLE
Add tvOS support to the podspec file

### DIFF
--- a/RNMillicastWebRTC/118.0.0-4d27b948/RNMillicastWebRTC.podspec
+++ b/RNMillicastWebRTC/118.0.0-4d27b948/RNMillicastWebRTC.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
                           type: :zip,
                           :headers => ["Authorization: Bearer #{ ENV['GITHUB_PERSONAL_ACCESS_TOKEN'] }", "Accept: application/octet-stream"]
                        }
-  s.ios.deployment_target   = "12.4"
+  s.platforms           = { :ios => '14.0', :tvos => '14.0' }
   s.vendored_frameworks     = [ 'WebRTC.xcframework' ]
 end


### PR DESCRIPTION
Description:

Add tvOS platform support to spec file
Set the deployment target version to 14.0 which is the version we used to build the xcframework.